### PR TITLE
Make the library public

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (library
-  (name dum)
+  (public_name dum)
   (modules dum)
   (libraries easy-format))


### PR DESCRIPTION
The dune ported library was private, making it impossible to use it in a duniverse.